### PR TITLE
Rename application to plug_healthz

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `sanito` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:sanito, "~> 0.1.0"}
+    {:plug_healthz, "~> 0.1.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Sanito.MixProject do
   defp package do
     [
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/resuelve/sanito"}
+      links: %{"GitHub" => "https://github.com/resuelve/plug_healthz"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Sanito.MixProject do
 
   def project do
     [
-      app: :sanito,
+      app: :plug_healthz,
       version: "0.1.0",
       elixir: "~> 1.12",
       description: "Plug health check module",
@@ -17,7 +17,7 @@ defmodule Sanito.MixProject do
   defp package do
     [
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/erickgnavar/sanito"}
+      links: %{"GitHub" => "https://github.com/resuelve/sanito"}
     ]
   end
 


### PR DESCRIPTION
### Context
This PR renames the application to `plug_healthz`.

All other module names, function names, and functionality remain unchanged to maintain compatibility and consistency.

### Why?
The rename is required in order to publish the project under the Bravo organization.

